### PR TITLE
Add better tsschecker binary check/error messaging

### DIFF
--- a/getshsh.sh
+++ b/getshsh.sh
@@ -142,17 +142,12 @@
 #       c59f236f2da3921879963c4699ae060a6585ee8f
 #
 
-if [ ! -e "/usr/local/bin/tsschecker" ]; then
-    echo "Cannot find tsschecker binary in /usr/local/bin/"
-elif [ -e "/usr/local/bin/tsschecker" ]; then
-    echo "Found tsschecker in /usr/local/bin/"
-    TSS=/usr/local/bin/tsschecker
-elif [ ! -e "tsschecker" ]; then
-    echo "Error: Cannot find tsschecker binary. Please put tsschecker in project directory."
+
+if [ ! -z $(command -v tsschecker) ]; then
+    TSS=$(command -v tsschecker)
+elif [ -z $(command -v tsschecker) ]; then
+    echo "Error: Cannot find tsschecker binary. Please install tsschecker and add it to your PATH"
     exit
-elif [ -e "tsschecker" ]; then
-    echo "Found tsschecker in project directory"
-    TSS=./tsschecker
 fi
 
 if [ $# -lt 5 ]; then

--- a/getshsh.sh
+++ b/getshsh.sh
@@ -142,9 +142,17 @@
 #       c59f236f2da3921879963c4699ae060a6585ee8f
 #
 
-if [ ! -e "tsschecker" ]; then
-    echo "Please put tsschecker."
+if [ ! -e "/usr/local/bin/tsschecker" ]; then
+    echo "Cannot find tsschecker binary in /usr/local/bin/"
+elif [ -e "/usr/local/bin/tsschecker" ]; then
+    echo "Found tsschecker in /usr/local/bin/"
+    TSS=/usr/local/bin/tsschecker
+elif [ ! -e "tsschecker" ]; then
+    echo "Error: Cannot find tsschecker binary. Please put tsschecker in project directory."
     exit
+elif [ -e "tsschecker" ]; then
+    echo "Found tsschecker in project directory"
+    TSS=./tsschecker
 fi
 
 if [ $# -lt 5 ]; then
@@ -267,7 +275,7 @@ if [ $# == 6 ]; then
         for nonce in ${ApNonce}
             do
                 echo "ApNonce: "$nonce""
-                ./tsschecker -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce $nonce 2>/dev/null >/dev/null &
+                $TSS -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce $nonce 2>/dev/null >/dev/null &
             done
         echo ""
     else
@@ -280,7 +288,7 @@ else
     for nonce in ${ApNonce}
         do
             echo "ApNonce: "$nonce""
-            ./tsschecker -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce $nonce 2>/dev/null >/dev/null
+            $TSS -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce $nonce 2>/dev/null >/dev/null
         done
     echo ""
 
@@ -288,7 +296,7 @@ fi
 
 ## Stopper ##
 echo "ApNonce: 05fe405753166f125559e7c9ac558654f107c7e9 (=0x0000000000000000 SHA1)"
-./tsschecker -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce 05fe405753166f125559e7c9ac558654f107c7e9
+$TSS -i $1 —d $2 --boardconfig $3 -e $4 --save-path $5 -s --apnonce 05fe405753166f125559e7c9ac558654f107c7e9
 
 
 


### PR DESCRIPTION
I have tsschecker v244 installed at /usr/local/bin/tsschecker (via @stek29's homebrew tap) but receive "Please put tsschecker" as terminal output/error when attempting to run getshsh.sh. Running on macOS 10.13.6

I'd suggest labeling the error better, by appending "binary in project directory" to that error message or checking if tsschecker is installed in /usr/local/bin, use that version